### PR TITLE
Fix: Trick or treat menu item now linked to the corresponding section

### DIFF
--- a/src/halloween.html
+++ b/src/halloween.html
@@ -148,7 +148,7 @@
                 </div>
                 <div class="col-md-6">
                     <div class="container">
-                     <h2 class="body-header">Trick or Treat !!</h2>
+                     <h2 id="trickortreat" class="body-header">Trick or Treat !!</h2>
                      <p class="mt-3 body-paragraph">
                         Borrowing from Irish and English traditions, Americans began to dress up in costumes and go house to house 
                         asking for food or money, a practice that eventually became today’s “trick-or-treat” tradition. 


### PR DESCRIPTION
I noticed the trick or treat link was not linking to the corresponding section on the Halloween page. I fixed the link.