### PR TITLE
set height to auto for mobile

### DIFF
--- a/src/style/home/home.css
+++ b/src/style/home/home.css
@@ -602,6 +602,19 @@ body > .container {
   height: 100% !important;
   margin: auto;
 }
+@media(max-width: 1024px) {
+  #myCarousel,
+  .carousel-inner,
+  .carousel-inner > .item,
+  .carousel-control {
+    height: auto;
+  }
+  .carousel-inner > .item > img,
+  .carousel-inner > .item > a > img {
+    height: auto;
+  }
+  
+}
 
 /* ===== Card ===== */
 .card-container {


### PR DESCRIPTION
Carousel image text was illegible on mobile. I understand it does break the aesthetic of full height splash images. But the Aspect ratio was braking. I hope its an ok commit. Let me know if there are any problems.